### PR TITLE
added profile ID to the camper application and volunteer application …

### DIFF
--- a/src/components/applicationFrame.vue
+++ b/src/components/applicationFrame.vue
@@ -265,6 +265,7 @@
 			},
 			constCamperApp: function() {
 				return {
+					profileId: this.profile._id.$oid,
 					full_name: this.profile.full_name,
 					email: this.profile.email,
 					address_line_1: this.appState.address1,
@@ -286,6 +287,7 @@
 			},
 			constVolunteerApp: function() {
 				return {
+					profileId: this.profile._id.$oid,
 					full_name: this.profile.full_name,
 					email: this.profile.email,
 					address_line_1: this.appState.address1,


### PR DESCRIPTION
…- to keep better track of applicant identifier (in case applicant email changes in the future)

Issue Addressed:
Submitted applications are currently keeping track of the applicant email - but the profiles allow users to change email addresses. This would potentially create the situation that a user could change their email address, and then detach their application from their account.

This small change will include that applicant ID with the application to better connect applications and applicants.

A future change will need to relate applications to users by this ID on the profile pages.

NOTE: This change does not modify the email saved with the application. The email currently remains static - and will not change on the application page if the user changes their email address at a later date. To change this field - would require further changes to all the components that read the application email field. 

If you would like to implement this change, I would suggest adding a new ticket.